### PR TITLE
Shim FormData submitter

### DIFF
--- a/assets/frontend/woo-ajax-add-to-cart.js
+++ b/assets/frontend/woo-ajax-add-to-cart.js
@@ -3,7 +3,9 @@
 	function serializeForm(form, submitter) {
 		var formData = new FormData(form, submitter);
 		var serializedObject = {};
-	
+
+		formData.append('product_id', $(submitter).val());
+
 		formData.forEach(function(value, key) {
 			if (key.includes('[')) {
 				var keys = key.split(/\[|\]/).filter(function(k) { return k; });


### PR DESCRIPTION
Older browsers do not have a second parameter for `FormData()`.
Items simply won't get into the cart without a product ID.

docs: https://developer.mozilla.org/en-US/docs/Web/API/FormData#browser_compatibility

This is not a nice fix.